### PR TITLE
TypeError: can only compare to a set

### DIFF
--- a/toysm/fsm.py
+++ b/toysm/fsm.py
@@ -156,7 +156,7 @@ class StateMachine(object):
                 version from the function.
         '''
         allowed_kargs = {'demux'}
-        if not kargs.keys() <= allowed_kargs:
+        if not set(kargs.keys()) <= allowed_kargs:
             raise TypeError("Unexpected keyword argument(s) '%s'" %
                             (list(kargs - allowed_kargs)))
         if states:
@@ -250,7 +250,7 @@ class StateMachine(object):
                   SMState should be used.
         '''
         allowed_kargs = {'sm_state'}
-        if not kargs.keys() <= allowed_kargs:
+        if not set(kargs.keys()) <= allowed_kargs:
             raise TypeError("Unexpected keyword argument(s) '%s'" %
                             (list(kargs - allowed_kargs)))
         self._settled.clear()


### PR DESCRIPTION
The code does not work (Python 2.7) , a type exception is raised : 

```
Traceback (most recent call last):
  File "fsm.py", line 569, in <module>
    state_machine = StateMachine(state_s0)
  File "fsm.py", line 159, in __init__
    if not kargs.keys() <= allowed_kargs:
TypeError: can only compare to a set
```

Need to cast kargs.keys() into a set
